### PR TITLE
Fix: Check if the directory exists prior to modular data cleanup (bsc#1184311)

### DIFF
--- a/java/code/src/com/redhat/rhn/taskomatic/task/ModularDataCleanup.java
+++ b/java/code/src/com/redhat/rhn/taskomatic/task/ModularDataCleanup.java
@@ -49,8 +49,15 @@ public class ModularDataCleanup extends RhnJavaJob {
         Set<Path> usedModularDataAbsolutePaths = usedModularDataPaths.stream()
                 .map(relPath -> Path.of(MOUNT_POINT_PATH, relPath))
                 .collect(Collectors.toSet());
+
+        File modulesPath = Path.of(MOUNT_POINT_PATH, MODULES_REL_PATH).toFile();
+        if (!modulesPath.exists()) {
+            log.info(String.format("Modules directory " + modulesPath + " does not exist. Skipping cleanup"));
+            return;
+        }
+
         Collection<File> modularDataFiles = FileUtils.listFiles(
-                Path.of(MOUNT_POINT_PATH, MODULES_REL_PATH).toFile(),
+                modulesPath,
                 new SuffixFileFilter("modules.yaml"),
                 TrueFileFilter.TRUE);
 

--- a/java/spacewalk-java.changes
+++ b/java/spacewalk-java.changes
@@ -1,3 +1,4 @@
+- Check if the directory exists prior to modular data cleanup (bsc#1184311)
 - Fix docs link in my organization configuration (bsc#1184286)
 - Provide Custom Info as Pillar data
 - remove deprecated xmlrpc functions


### PR DESCRIPTION
When searching the modular data (`modules.yaml`) for cleanup, the code assumed the directory (typically `/var/spacewalk/rhn/modules`) exist.
This PR adds a simple existence check and logs a descriptive message to the log, in case the directory does not exist.


## Documentation
fix
- [x] **DONE**

## Test coverage

- [ ] **DONE**

## Links

tracks https://github.com/SUSE/spacewalk/issues/14463

- [x] **DONE**

## Changelogs

If you don't need a changelog check, please mark this checkbox:

- [ ] No changelog needed

If you uncheck the checkbox after the PR is created, you will need to re-run `changelog_test` (see below)


## Re-run a test

If you need to re-run a test, please mark the related checkbox, it will be unchecked automatically once it has re-run:

- [ ] Re-run test "changelog_test"
- [ ] Re-run test "backend_unittests_pgsql"
- [ ] Re-run test "java_pgsql_tests"
- [ ] Re-run test "schema_migration_test_oracle"
- [ ] Re-run test "schema_migration_test_pgsql"
- [ ] Re-run test "susemanager_unittests"
- [ ] Re-run test "javascript_lint"
- [ ] Re-run test "spacecmd_unittests"